### PR TITLE
fix: Support git worktrees in commitlint hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,5 +16,6 @@
 - id: commitlint
   name: Commitlint
   description: Lint commit messages according to the conventional conventions
-  entry: extenda/commitlint
-  language: docker_image
+  entry: pre_commit_hooks/commitlint.sh
+  language: script
+  stages: [commit-msg]

--- a/pre_commit_hooks/commitlint.sh
+++ b/pre_commit_hooks/commitlint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Read the commit message on the host and pipe it into the commitlint
+# container on stdin. Reading on the host avoids bind-mount issues when
+# the repo is a git worktree (where .git is a file pointing outside the
+# working tree).
+set -euo pipefail
+exec docker run --rm -i extenda/commitlint < "$1"


### PR DESCRIPTION
Switch the commitlint hook from language: docker_image to language: script with a small wrapper that reads the commit-msg file on the host and pipes it into the extenda/commitlint container on stdin.

With language: docker_image, pre-commit bind-mounts the working tree into the container and passes the COMMIT_EDITMSG path. In a git worktree the file lives at <main>/.git/worktrees/<name>/COMMIT_EDITMSG, outside the mount, so the container can't read it and the commit aborts.

Reading on the host sidesteps mount and gitdir resolution entirely. The extenda/commitlint image already accepts a message on stdin.